### PR TITLE
feature: Assetsort 메뉴바 각 요소 정렬 기능 완성

### DIFF
--- a/src/components/Asset.js
+++ b/src/components/Asset.js
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
+import assetMock from "../assetMockData.json";
+import axios from "axios";
 
 const Span = styled.span`
   margin-left: 20px;
@@ -12,10 +14,34 @@ const Div = styled.div`
 `;
 
 export default function Asset() {
-  const { asset } = useSelector((state) => state.user.user);
+  // const { asset } = useSelector((state) => state.user.user);
 
-  const ownedCash = asset.cash;
-  const ownedCoinList = asset.coins;
+  // const ownedCash = asset.cash;
+  // const ownedCoinList = asset.coins;
+
+  const userId = useSelector((state) => state.user.userId);
+  const token = useSelector((state) => state.user.token);
+  const [assetList, setAssetList] = useState({});
+  const [isSort, setIsSort] = useState(false);
+
+  const ownedCash = assetMock.asset.cash;
+  const ownedCoinList = assetMock.asset.coins;
+  let coinListForRender = null;
+
+  useEffect(() => {
+    const fetchAssetData = async function () {
+      const res = await axios.get(
+        `${process.env.REACT_APP_ASSET_REQUEST}/${userId}`,
+        {
+          headers: { authorization: token },
+        }
+      );
+
+      setAssetList(res.data.userAsset);
+    };
+
+    fetchAssetData();
+  }, []);
 
   const getCurrentLeftMoney = (coin) => {
     const leftMoney =
@@ -23,9 +49,22 @@ export default function Asset() {
     return leftMoney;
   };
 
+  const ascendCoinName = () => {
+    setIsSort(true);
+    return (coinListForRender = ownedCoinList.sort(function (a, b) {
+      return a.currencyName < b.currencyName
+        ? -1
+        : a.currencyName > b.currencyName
+        ? 1
+        : 0;
+    }));
+  };
+
   return (
     <>
-      <Span>자산 구분</Span>
+      <Span>
+        자산 구분 <button onClick={ascendCoinName}>↕️</button>
+      </Span>
       <Span>보유 잔고</Span>
       <Span>평균 매수가</Span>
       <Span>매수 금액</Span>
@@ -33,15 +72,27 @@ export default function Asset() {
       <Span>펑가 순익</Span>
       <Span>수익률</Span>
 
-      {ownedCoinList.map((coinElements) => {
-        return (
-          <Div key={coinElements.currencyName}>
-            <Span>{coinElements.currencyName}</Span>
-            <Span>{`${getCurrentLeftMoney(coinElements)}원`}</Span>
-            <Span>{coinElements.averagePrice}</Span>
-          </Div>
-        );
-      })}
+      {!isSort
+        ? ownedCoinList.map((coinElements) => {
+            console.log("!!!!", coinElements);
+            return (
+              <Div key={coinElements.currencyName}>
+                <Span>{coinElements.currencyName}</Span>
+                <Span>{`${getCurrentLeftMoney(coinElements)}원`}</Span>
+                <Span>{coinElements.averagePrice}</Span>
+              </Div>
+            );
+          })
+        : coinListForRender.map((coinElements) => {
+            console.log("!!!!", coinElements);
+            return (
+              <Div key={coinElements.currencyName}>
+                <Span>{coinElements.currencyName}</Span>
+                <Span>{`${getCurrentLeftMoney(coinElements)}원`}</Span>
+                <Span>{coinElements.averagePrice}</Span>
+              </Div>
+            );
+          })}
     </>
   );
 }

--- a/src/components/Asset.js
+++ b/src/components/Asset.js
@@ -22,16 +22,26 @@ export default function Asset() {
   const [socketData, setSocketData] = useState("");
   const [renderedAssetList, setRenderedAssetList] = useState({});
   const [isSortBtnClick, setIsSortBtnClick] = useState(false);
-  const [isAscendSortByName, setIsAscendSortByName] = useState(true);
-  const [isAscendSortByLeftMoney, setIsAscendSortByLeftMoney] = useState(true);
-  const [isAscendSortByAvgPrice, setIsAscendSortByAvgPrice] = useState(true);
-  const [isAscendSortByBoughtPrice, setIsAscendSortByBoughtPrice] =
-    useState(true);
-  const [isAscendSortByEvaluatedPrice, setIsAscendSortByEvaluatedPrice] =
-    useState(true);
-  const [isAscendSortByEvaluatedProfit, setIsAscendSortByEvaluatedProfit] =
-    useState(true);
-  const [isAscendSortByYieldRate, setIsAscendSortByYieldRate] = useState(true);
+
+  const [isAscendSort, setIsAscendSort] = useState({
+    isName: true,
+    isLeftMoney: true,
+    isAvgPrice: true,
+    isBoughtPrice: true,
+    isEvaluatedPrice: true,
+    isEvaluatedProfit: true,
+    isYieldRate: true,
+  });
+
+  const {
+    isName,
+    isLeftMoney,
+    isAvgPrice,
+    isBoughtPrice,
+    isEvaluatedPrice,
+    isEvaluatedProfit,
+    isYieldRate,
+  } = isAscendSort;
 
   useEffect(() => {
     ws.onmessage = (event) => {
@@ -89,9 +99,12 @@ export default function Asset() {
 
   const sortingByCoinName = () => {
     setIsSortBtnClick(true);
-    setIsAscendSortByName((current) => !current);
+    setIsAscendSort({
+      ...isAscendSort,
+      isName: !isName,
+    });
 
-    isAscendSortByName
+    isName
       ? setRenderedAssetList(
           newCoinList.sort((a, b) => {
             return a.currencyName < b.currencyName
@@ -114,9 +127,12 @@ export default function Asset() {
 
   const sortingByCurrentLeftMoney = () => {
     setIsSortBtnClick(true);
-    setIsAscendSortByLeftMoney((current) => !current);
+    setIsAscendSort({
+      ...isAscendSort,
+      isLeftMoney: !isLeftMoney,
+    });
 
-    isAscendSortByLeftMoney
+    isLeftMoney
       ? setRenderedAssetList(
           newCoinList.sort((a, b) => {
             return a.quantity < b.quantity
@@ -139,137 +155,114 @@ export default function Asset() {
 
   const averageBoughtPrice = () => {
     setIsSortBtnClick(true);
-    setIsAscendSortByAvgPrice((current) => !current);
+    setIsAscendSort({
+      ...isAscendSort,
+      isAvgPrice: !isAvgPrice,
+    });
 
-    isAscendSortByAvgPrice
+    isAvgPrice
       ? setRenderedAssetList(
           newCoinList.sort((a, b) => {
-            return a.averagePrice < b.averagePrice
-              ? -1
-              : a.averagePrice > b.averagePrice
-              ? 1
-              : 0;
+            return a.averagePrice - b.averagePrice;
           })
         )
       : setRenderedAssetList(
           newCoinList.sort((a, b) => {
-            return a.averagePrice > b.averagePrice
-              ? -1
-              : a.averagePrice < b.averagePrice
-              ? 1
-              : 0;
+            return b.averagePrice - a.averagePrice;
           })
         );
   };
 
   const boughtPrice = () => {
     setIsSortBtnClick(true);
-    setIsAscendSortByBoughtPrice((current) => !current);
+    setIsAscendSort({
+      ...isAscendSort,
+      isBoughtPrice: !isBoughtPrice,
+    });
 
-    isAscendSortByBoughtPrice
+    isBoughtPrice
       ? setRenderedAssetList(
           newCoinList.sort((a, b) => {
-            return a.bought_price < b.bought_price
-              ? -1
-              : a.bought_price > b.bought_price
-              ? 1
-              : 0;
+            return a.bought_price - b.bought_price;
           })
         )
       : setRenderedAssetList(
           newCoinList.sort((a, b) => {
-            return a.bought_price > b.bought_price
-              ? -1
-              : a.bought_price < b.bought_price
-              ? 1
-              : 0;
+            return b.bought_price - a.bought_price;
           })
         );
   };
 
   const evaluatedPrice = () => {
     setIsSortBtnClick(true);
-    setIsAscendSortByEvaluatedPrice((current) => !current);
+    setIsAscendSort({
+      ...isAscendSort,
+      isEvaluatedPrice: !isEvaluatedPrice,
+    });
 
-    isAscendSortByEvaluatedPrice
+    isEvaluatedPrice
       ? setRenderedAssetList(
           newCoinList.sort((a, b) => {
-            return a.quantity * a.current_price < b.quantity * b.current_price
-              ? -1
-              : a.quantity * a.current_price > b.quantity * b.current_price
-              ? 1
-              : 0;
+            return a.quantity * a.current_price - b.quantity * b.current_price;
           })
         )
       : setRenderedAssetList(
           newCoinList.sort((a, b) => {
-            return a.quantity * a.current_price > b.quantity * b.current_price
-              ? -1
-              : a.quantity * a.current_price < b.quantity * b.current_price
-              ? 1
-              : 0;
+            return b.quantity * b.current_price - a.quantity * a.current_price;
           })
         );
   };
 
   const evaluatedProfit = () => {
     setIsSortBtnClick(true);
-    setIsAscendSortByEvaluatedProfit((current) => !current);
+    setIsAscendSort({
+      ...isAscendSort,
+      isEvaluatedProfit: !isEvaluatedProfit,
+    });
 
-    isAscendSortByEvaluatedProfit
+    isEvaluatedProfit
       ? setRenderedAssetList(
           newCoinList.sort((a, b) => {
-            return a.quantity * a.current_price - a.bought_price <
-              b.quantity * b.current_price - b.bought_price
-              ? -1
-              : a.quantity * a.current_price - a.bought_price >
-                b.quantity * b.current_price - b.bought_price
-              ? 1
-              : 0;
+            return (
+              a.quantity * a.current_price -
+              a.bought_price -
+              (b.quantity * b.current_price - b.bought_price)
+            );
           })
         )
       : setRenderedAssetList(
           newCoinList.sort((a, b) => {
-            return a.quantity * a.current_price - a.bought_price >
-              b.quantity * b.current_price - b.bought_price
-              ? -1
-              : a.quantity * a.current_price - a.bought_price <
-                b.quantity * b.current_price - b.bought_price
-              ? 1
-              : 0;
+            return (
+              b.quantity * b.current_price -
+              b.bought_price -
+              (a.quantity * a.current_price - a.bought_price)
+            );
           })
         );
   };
 
   const yieldRate = () => {
     setIsSortBtnClick(true);
-    setIsAscendSortByYieldRate((current) => !current);
+    setIsAscendSort({
+      ...isAscendSort,
+      isYieldRate: !isYieldRate,
+    });
 
-    isAscendSortByYieldRate
+    isYieldRate
       ? setRenderedAssetList(
           newCoinList.sort((a, b) => {
-            return (a.quantity * a.current_price - a.bought_price) /
-              a.bought_price <
+            return (
+              (a.quantity * a.current_price - a.bought_price) / a.bought_price -
               (b.quantity * b.current_price - b.bought_price) / b.bought_price
-              ? -1
-              : (a.quantity * a.current_price - a.bought_price) /
-                  a.bought_price >
-                (b.quantity * b.current_price - b.bought_price) / b.bought_price
-              ? 1
-              : 0;
+            );
           })
         )
       : setRenderedAssetList(
           newCoinList.sort((a, b) => {
-            return (a.quantity * a.current_price - a.bought_price) /
-              a.bought_price >
-              (b.quantity * b.current_price - b.bought_price) / b.bought_price
-              ? -1
-              : (a.quantity * a.current_price - a.bought_price) /
-                  a.bought_price <
-                (b.quantity * b.current_price - b.bought_price) / b.bought_price
-              ? 1
-              : 0;
+            return (
+              (b.quantity * b.current_price - b.bought_price) / b.bought_price -
+              (a.quantity * a.current_price - a.bought_price) / a.bought_price
+            );
           })
         );
   };
@@ -278,45 +271,38 @@ export default function Asset() {
     <>
       <Span>
         자산 구분
-        <button onClick={sortingByCoinName}>
-          {!isAscendSortByName ? "🔼" : "🔽"}
-        </button>
+        <button onClick={sortingByCoinName}>{!isName ? "🔼" : "🔽"}</button>
       </Span>
       <Span>
         보유 잔고
         <button onClick={sortingByCurrentLeftMoney}>
-          {!isAscendSortByLeftMoney ? "🔼" : "🔽"}
+          {!isLeftMoney ? "🔼" : "🔽"}
         </button>
       </Span>
       <Span>
         평균 매수가
         <button onClick={averageBoughtPrice}>
-          {!isAscendSortByAvgPrice ? "🔼" : "🔽"}
+          {!isAvgPrice ? "🔼" : "🔽"}
         </button>
       </Span>
       <Span>
         매수 금액
-        <button onClick={boughtPrice}>
-          {!isAscendSortByBoughtPrice ? "🔼" : "🔽"}
-        </button>
+        <button onClick={boughtPrice}>{!isBoughtPrice ? "🔼" : "🔽"}</button>
       </Span>
       <Span>
         평가 금액
         <button onClick={evaluatedPrice}>
-          {!isAscendSortByEvaluatedPrice ? "🔼" : "🔽"}
+          {!isEvaluatedPrice ? "🔼" : "🔽"}
         </button>
       </Span>
       <Span>
         펑가 순익
         <button onClick={evaluatedProfit}>
-          {!isAscendSortByEvaluatedProfit ? "🔼" : "🔽"}
+          {!isEvaluatedProfit ? "🔼" : "🔽"}
         </button>
       </Span>
       <Span>
-        수익률{" "}
-        <button onClick={yieldRate}>
-          {!isAscendSortByEvaluatedProfit ? "🔼" : "🔽"}
-        </button>
+        수익률 <button onClick={yieldRate}>{!isYieldRate ? "🔼" : "🔽"}</button>
       </Span>
 
       {!isSortBtnClick

--- a/src/features/sagas/socketSaga.js
+++ b/src/features/sagas/socketSaga.js
@@ -9,7 +9,6 @@ import {
 } from "./socketSlice";
 
 function* getCoinList({ payload }) {
-  console.log("페이로드:::", payload);
   try {
     const ticker = yield axios.get(
       `https://api.bithumb.com/public/ticker/${payload}`


### PR DESCRIPTION
- 구현 내용
자산 현황 Asset 컴포넌트에서 메뉴바 각 요소마다 정렬이 가능한 기능을 구현했습니다.

- 설명
기본 렌더링 하는 데이터를 DB의 asset 데이터와 transactionHistory 의 price(매수가) 데이터를 한 객체에 담았고, parsedCoinList 라는 변수명을 지어줘 배열로 만들었습니다.
기본 렌더링 하는 객체에는 [자산 구분, 보유 잔고, 평균 매수가, 매수 금액] 데이터가 있습니다.

평가 금액, 평균 순익, 수익률은 코인의 시세(시장가)가 있어야 구할 수 있는 값으로 webSocket을 Asset 컴포넌트에서도 실행시켜 코인 데이터의 시세만 로컬 state에 담아 관리했습니다.(socketData)

각 메뉴바의 요소들 마다 버튼을 주었습니다. 오름 차순, 내림 차순으로 정렬 되며 렌더링은 맨처음엔 DB에 쌓여 있는대로 보여주고 정렬 버튼을 누르면 그 때 정렬되는 순서대로 정렬시켜줍니다.

- 특이사항
많은 변수명이 필요해 구분하기 위해 자세하게 작성했습니다. 그러다보니 좀 길어졌는데 더 간략한 변수명이 생각나신다면 조언해주시면 감사하겠습니다.

메뉴바의 각 요소마다 각기 다르게 정렬을 할 수 있게 하려다보니 정렬 함수가 많아 코드가 길어져 가독성이 안 좋습니다. util 함수로 빼거나 다른 방법을 고민해 코드 가독성을 높일 수 있도록 하겠습니다.